### PR TITLE
Arreglar el cargar notas digitales en las notas debito/credito proveedor...

### DIFF
--- a/clases/modulos/NotaCreditoProveedor.php
+++ b/clases/modulos/NotaCreditoProveedor.php
@@ -323,8 +323,6 @@ class NotaCreditoProveedor {
         
     }
 
-  
-
     /**
      *
      * Eliminar una nota
@@ -363,7 +361,6 @@ class NotaCreditoProveedor {
         }
         
     }
-    
     
     /**
      * Cargar los datos de una nota
@@ -430,6 +427,15 @@ class NotaCreditoProveedor {
 
         if (!$validarFormato) {
             $configuracionRuta = $configuracion["RUTAS"]["media"] . "/" . $configuracion["RUTAS"]["archivos"] . '/'.$tipo.'/';
+            
+            if (!is_file($configuracionRuta)) {
+                mkdir($configuracionRuta, 7777);
+            }
+            
+            if (!is_writable($configuracionRuta)) {
+                chmod($configuracionRuta, 7777);
+            }
+            
             $recurso = Archivo::subirArchivoAlServidor($archivo, $configuracionRuta);
             
             if ($recurso) {

--- a/clases/modulos/NotaDebitoProveedor.php
+++ b/clases/modulos/NotaDebitoProveedor.php
@@ -422,6 +422,15 @@ class NotaDebitoProveedor {
 
         if (!$validarFormato) {
             $configuracionRuta = $configuracion["RUTAS"]["media"] . "/" . $configuracion["RUTAS"]["archivos"] . '/'.$tipo.'/';
+            
+            if (!is_file($configuracionRuta)) {
+                mkdir($configuracionRuta, 7777);
+            }
+            
+            if (!is_writable($configuracionRuta)) {
+                chmod($configuracionRuta, 7777);
+            }            
+            
             $recurso = Archivo::subirArchivoAlServidor($archivo, $configuracionRuta);
             
             if ($recurso) {

--- a/modulos/facturas_compra/ajax.php
+++ b/modulos/facturas_compra/ajax.php
@@ -1358,18 +1358,14 @@ function adicionarNotaCredito($id, $datos = array()) {
         
         $contenedorListaArticles = HTML::tabla($datosTabla, $listaArticulos, $clase, $idTabla, $clasesColumnas, $clasesFilas, $opciones);
 
-
-
         $contenedor1 = HTML::contenedor($codigo1, 'contenedorIzquierdo margenInferiorDoble');
         $contenedor2 = HTML::contenedor($codigo2, 'contenedorDerecho margenInferiorDoble');
         $contenedor3 = HTML::contenedor($contenedorListaArticles, 'contenedorListadoArticulos oculto', 'contenedorListaArticulosNota');
-
-
+        
         $codigo .= $contenedor1 . $contenedor2 . $contenedor3;
         $codigo .= HTML::parrafo(HTML::boton('chequeo', $textos->id('ACEPTAR'), ' margenSuperiorTriple', 'botonOk', 'botonOk'), 'margenSuperiorTriple');
         $codigo .= HTML::parrafo($textos->id('NOTA_CREDITO_ADICIONADA_A_FACTURA'), 'textoExitoso', 'textoExitoso');
         $codigo1 = HTML::forma($destino, $codigo, 'P');
-
 
         $respuesta['generar']       = true;
         $respuesta['cargarJs']      = true;


### PR DESCRIPTION
Arreglar el cargar notas digitales en las notas debito/credito proveedor. Se agrega la validacion si existe la carpeta donde se van a guardar los archivos, y en caso de que no exista, o no haya permisos de escritura, se crea la carpeta y se le asignan permisos 7777
